### PR TITLE
About Us page changes

### DIFF
--- a/src/components/aboutComponent.js
+++ b/src/components/aboutComponent.js
@@ -60,7 +60,16 @@ function AboutComponent(props) {
                         </div>
                 ))}
             </Grid>
-        </div>
+
+            <Grid container spacing={3} alignItems="center" justifyContent="center">
+            <p>
+                <a href={props.learnMore} target="_blank" rel="noopener noreferrer" className="learn-more">
+                    Learn More
+                </a>
+            </p>
+            </Grid>
+
+        </div>  
     );
 }
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -120,6 +120,7 @@ function AboutPage({ data }) {
             subteam={"Emerging Tech"}
             members={emergingMembers}
             about={"The emerging tech team is comprised of students from a variety of different backgrounds and majors, including Computational Media and Computer Science. The team focuses on exploring cutting edge technologies and their ability to create empathy."}
+            learnMore={"https://educast.library.gatech.edu/emergingtech/"}
           />
         </div>
 
@@ -129,6 +130,7 @@ function AboutPage({ data }) {
             subteam={"Web"}
             members={webMembers}
             about={"The Web team is comprised of students from a variety of backgrounds, such as Computer Science and Computational Media. The team maintains the external facing Empathy Bytes website which uses GatsbyJS, GraphQL, and Drupal. The team also is exploring Web XR and its capabilities to create unique and memorable experiences."}
+            learnMore={"https://educast.library.gatech.edu/webteam/"}
           />
         </div>
 
@@ -139,6 +141,7 @@ function AboutPage({ data }) {
             subteam={"Media"}
             members={mediaMembers}
             about={"The Media team is comprised of students from a variety of backgrounds, such as Computer Science and Computational Media. The team creates media content for the site in addition to working across teams to help with design needs."}
+            learnMore={"https://educast.library.gatech.edu/mediateam/"}
           />
         </div>
 
@@ -148,6 +151,7 @@ function AboutPage({ data }) {
             subteam={"App"}
             members={appMembers}
             about={"The App team is comprised of students from a variety of backgrounds, such as Computer Science and Computational Media. The team is currently creating a Mobile Application to present the teams research with future hopes of publishing on the Apple Store."}
+            learnMore={"https://educast.library.gatech.edu/appteam/"}
           />
         </div>
       </div>

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -66,22 +66,28 @@
 }
 
 .about-nav-text {
-    font-size: 1rem;
-    font-family: 'Roboto Slab', sans-serif;
-    color: white;
-    padding: 10%;
-    border-radius: 150px;
+  display: inline-block;
+  font-size: 18px;
+  font-family: 'Roboto Slab', sans-serif;
+  color: #003057;
+  padding: 17px 40px;
+  background-color: white;
+  border-radius: 150px;
+  text-align: center;
+  cursor: pointer;
+  text-decoration: none;
+  min-width: 100px;
 }
 
 .about-nav-text:hover {
-    background-color: #003057;
+    background-color: #E0BB56;
     cursor: pointer;
     transition: background-color 200ms linear;
 }
 
 .navBG {
     display: flex;
-    background-color: #1B3F66;
+    /* background-color: #1B3F66; */
     border-radius: 150px;
     width: 90%;
     height: 50%;
@@ -183,4 +189,16 @@
     height: 150px;
     width: 300px;
     margin: auto;
-}
+  }
+
+  .learn-more {
+    color: #E0BB56;
+    text-align: center;
+    font-family: "Roboto Slab";
+    font-size: 25px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+    text-decoration-line: underline;
+  }
+  


### PR DESCRIPTION
Summary: basic UI changes for more consistency and connection to other pages on website

BEFORE:
<img width="1440" alt="Screen Shot 2024-04-26 at 11 12 31 PM" src="https://github.com/EmpathyBytes/empathy-bytes-2024/assets/143684205/298caf0a-dd83-41e8-87bf-a412aeb36411">
<img width="1440" alt="Screen Shot 2024-04-26 at 11 12 51 PM" src="https://github.com/EmpathyBytes/empathy-bytes-2024/assets/143684205/ba32d615-db0d-47d0-acea-0ee70c5441b4">

AFTER:
<img width="1440" alt="Screen Shot 2024-04-26 at 11 16 21 PM" src="https://github.com/EmpathyBytes/empathy-bytes-2024/assets/143684205/4aa50697-8d97-47b8-8913-43f46d43bafe">
<img width="1440" alt="Screen Shot 2024-04-26 at 11 12 58 PM" src="https://github.com/EmpathyBytes/empathy-bytes-2024/assets/143684205/65c0eabf-8b71-4da3-80cc-b1534b49f170">


*some aspects of before screenshots have been changed in previous pull requests (particularly background color), but highlighting the changes that I implemented in this pull request:
- navbar used for changing between different subteams in About Us page is changed to buttons
- colors also changed to be more consistent across web pages and hover color changed to yellow to be more distinguishable
- Learn More button used to navigate to respective subteam's Experiences pages